### PR TITLE
Fix translation for über

### DIFF
--- a/linguee_api/parser_utils.py
+++ b/linguee_api/parser_utils.py
@@ -55,3 +55,11 @@ def take_first_item(variants) -> Optional[str]:
     if not variants["item"]:
         return None
     return variants["item"][0]
+
+
+def take_first_non_empty_item(variants) -> Optional[str]:
+    """Take the first non-empty item variant and normalize."""
+    for item in variants["item"]:
+        if item:
+            return item
+    return None

--- a/linguee_api/parsers.py
+++ b/linguee_api/parsers.py
@@ -13,7 +13,12 @@ from linguee_api.models import (
     SearchResultOrError,
     UsageFrequency,
 )
-from linguee_api.parser_utils import concat_values, normalize, take_first_item
+from linguee_api.parser_utils import (
+    concat_values,
+    normalize,
+    take_first_item,
+    take_first_non_empty_item,
+)
 
 
 class IParser(abc.ABC):
@@ -237,12 +242,19 @@ lemma_schema = [
                 attr="onclick",
                 callback=parse_audio_links,
             ),
-            String(
+            Group(
                 name="usage_frequency",
-                quant="?",
-                css="span.tag_c",
-                attr="class",
-                callback=parse_usage_frequency,
+                quant=1,
+                callback=take_first_non_empty_item,
+                children=[
+                    String(
+                        name="item",
+                        quant="*",
+                        css="span.tag_c",
+                        attr="class",
+                        callback=parse_usage_frequency,
+                    ),
+                ],
             ),
             Group(
                 name="examples",

--- a/tests/parsers/test_search_result.py
+++ b/tests/parsers/test_search_result.py
@@ -93,6 +93,7 @@ async def test_parser_should_find_correction(
         ("wünschen", "de", "en"),
         ("envisage", "en", "zh"),
         ("envisage", "en", "sv"),
+        ("über", "de", "en"),
     ],
 )
 @pytest.mark.asyncio


### PR DESCRIPTION
Make sure that parser is not confused when it finds two elements that
look like the usage frequency.

Example:

"präp (temporal; e.g. for 3 years) (meistens verwendet)"

Closes #48
